### PR TITLE
chore: for windows runtime

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,8 +35,8 @@ jobs:
             ${{ runner.os }}-node-
       - run: pnpm i --frozen-lockfile # && npm install -g @lhci/cli@0.12.x
       - run: pnpm exec playwright install
-      - run: pnpm tsc
       - run: pnpm check
+      - run: pnpm tsc
       - run: pnpm fmt
       - run: pnpm lint
       - run: pnpm lint:mark

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,6 +35,7 @@ jobs:
             ${{ runner.os }}-node-
       - run: pnpm i --frozen-lockfile # && npm install -g @lhci/cli@0.12.x
       - run: pnpm exec playwright install
+      - run: pnpm check
       - run: pnpm fmt
       - run: pnpm lint
       - run: pnpm lint:mark

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,6 +35,7 @@ jobs:
             ${{ runner.os }}-node-
       - run: pnpm i --frozen-lockfile # && npm install -g @lhci/cli@0.12.x
       - run: pnpm exec playwright install
+      - run: pnpm tsc
       - run: pnpm check
       - run: pnpm fmt
       - run: pnpm lint

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "author": "s-hirano-ist",
   "packageManager": "pnpm@8.15.4",
   "scripts": {
-    "dev": "astro check --watch & astro dev",
-    "build": "astro check & astro build",
+    "check": "astro check",
+    "dev": "astro dev",
+    "build": "astro build",
     "preview": "astro preview",
     "sync": "astro sync",
     "astro": "astro",

--- a/package.json
+++ b/package.json
@@ -12,10 +12,11 @@
     "preview": "astro preview",
     "sync": "astro sync",
     "astro": "astro",
+    "tsc": "tsc --noEmit",
     "fmt": "prettier --cache --check **/*.astro .",
     "fmt:fix": "prettier --cache --write **/*.astro .",
-    "lint": "astro check && tsc --noEmit && eslint .",
-    "lint:fix": "astro check & tsc --noEmit & eslint . --fix",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "lint:mark": "markdownlint-cli2 src/content/summary/*",
     "lint:mark:fix": "markdownlint-cli2-fix src/content/summary/*",
     "lint:css": "stylelint .",
@@ -29,12 +30,16 @@
   },
   "lint-staged": {
     "*": [
+      "pnpm check",
       "pnpm fmt",
       "pnpm lint:secret"
     ],
-    "src/**/*.{js, jsx, ts, tsx, astro}": "pnpm lint",
-    "src/**/*.{css, astro}": "pnpm lint:css",
+    "src/**/*.{js, jsx, ts, tsx, astro}": [
+      "pnpm tsc",
+      "pnpm lint"
+    ],
     "_markdown/**/*.md": "pnpm lint:mark",
+    "src/**/*.{css, astro}": "pnpm lint:css",
     "src/**/*": "python3 script/generate_photo_path.py"
   },
   "dependencies": {


### PR DESCRIPTION
windows環境への対応+α

- buildコマンドに pnpm checkを追加
- package.jsonでcheckコマンドを分離
- Node.jsのバージョンを18から20にアップデート