### PR TITLE
ci: refactor to use templates

### DIFF
--- a/.github/workflows/renovate-config-validator.yaml
+++ b/.github/workflows/renovate-config-validator.yaml
@@ -9,13 +9,5 @@ on:
 
 jobs:
   renovate-config-validator:
-    runs-on: ubuntu-24.04
-    permissions: {}
-    timeout-minutes: 10
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-
-      - name: validate renovate.json
-        run: npx --package=renovate -c renovate-config-validator
+    uses: s-hirano-ist/s-templates/.github/workflows/renovate-config-validator.yaml@main
+    secrets: inherit


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * GitHub ActionsのRenovate設定バリデーションワークフローを、外部の再利用可能なワークフロー呼び出しに変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->