### PR TITLE
chore: upgrade pnpm to v11.0.8

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-save-exact=true

--- a/mise.toml
+++ b/mise.toml
@@ -3,7 +3,7 @@ _.file = ".env.local"
 
 [tools]
 node = "24.14.1"
-pnpm = "10.33.2"
+pnpm = "11.0.8"
 doppler = { version = "3.76.0", exe = "doppler" }
 terraform = "1.15.2"
 "npm:agent-browser" = "0.26.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "description": "Portfolio and blog pages of s-hirano-ist.",
   "author": "s-hirano-ist",
-  "packageManager": "pnpm@10.33.2",
+  "packageManager": "pnpm@11.0.8",
   "scripts": {
     "astro": "astro",
     "check": "astro check",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,10 @@
+saveExact: true
+
 overrides:
   diff@<8.0.3: ">=9.0.0"
+
+allowBuilds:
+  esbuild: true
+  sharp: true
+  unrs-resolver: true
+  vnu-jar: true


### PR DESCRIPTION
- Bump packageManager and mise.toml to pnpm@11.0.8 (Node 22+ already met).
- Move save-exact from .npmrc to pnpm-workspace.yaml as saveExact (v11
  reads only auth/registry settings from .npmrc).
- Add allowBuilds for esbuild, sharp, vnu-jar, unrs-resolver to satisfy
  v11's strictDepBuilds default.