### PR TITLE
docs: reconcile README/CLAUDE.md with reality and dedupe to single source

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -3,5 +3,6 @@
     "line-length": false, // MD013  行の長さ
     "no-inline-html": false
   },
+  "gitignore": true, // gitignore 済み（dist/.terraform 等の vendored）を除外
   "ignores": [".git", "node_modules", "CLAUDE.md"] // 無視するディレクトリ
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,11 +55,13 @@ src/
 - **ポートフォリオ**: JSON ファイルで管理（`src/data/portfolio/`）
 - **ライセンス**: `pnpm license:json` で `src/data/license/data.gen.json` を自動生成
 
+これらの生成系は `.github/workflows/update-contents.yaml` が週次でも自動実行し、更新を PR として作成する。
+
 ### 品質管理
 
-- Husky + lint-staged によるpre-commitフック
-- 複数のlinter並行実行（ESLint, Stylelint, markdownlint, secretlint）
-- Renovateによる依存関係自動更新
+- pre-commit フック: `.husky/pre-commit` + `package.json` の `lint-staged`
+- CI: `.github/workflows/`（`ci.yaml` で build / lint / lighthouse、`osv-scanner.yaml`・`dependency-review.yaml` で脆弱性・ライセンス検査）
+- 依存関係更新: Renovate（`.github/renovate.json5`）
 
 ### シークレット管理・インフラ
 
@@ -96,13 +98,8 @@ src/
 
 ### コミット前の確認
 
-lint-staged により以下が自動実行されます：
-
-- 型チェック（pnpm check, pnpm tsc）
-- フォーマット・リント（各種linter）
-- ライセンスチェック（bash checkLicense.sh）
+pre-commit で lint-staged が走る。対象パターンと実行内容は `package.json` の `lint-staged` を参照。
 
 ### リリース手順
 
-1. `package.json` の version を更新
-2. `gh release create --generate-notes` を実行
+README の「Tags & Release」を参照。

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 **HTML checker** - [Nu Html Checker](https://github.com/validator/validator)  
 **Lighthouse** - [LightHouse](https://developers.google.com/web/tools/lighthouse)  
 **SVG optimization** - [svgo](https://github.com/svg/svgo)  
-**Vulnerabilities Check** - [pnpm audit](https://pnpm.io/cli/audit) | [Dependabot alert](https://docs.github.com/ja/code-security/dependabot/dependabot-alerts/about-dependabot-alerts)
+**Vulnerabilities Check** - [pnpm audit](https://pnpm.io/cli/audit) | [OSV Scanner](https://github.com/google/osv-scanner) | [Dependency Review](https://github.com/actions/dependency-review-action)
 
 ### My infrastructure stack
 
@@ -102,30 +102,18 @@ echo "DOPPLER_TOKEN=$(terraform -chdir=terraform output -raw doppler_dev_ai_agen
 
 ### Adding photos
 
-Add photos to `./src/data/assets/photo/` and run:
+Add photos to `./src/data/assets/photo/`, then run `pnpm generate:photo`.
 
-```bash
-pnpm generate:photo
-```
+### Updating books
 
-### Update books
+Edit ISBN / metadata in `src/data/book/_original.ts`, then run `pnpm generate:book` (Google Books API).
 
-```bash
-pnpm generate:book
-```
+### Updating licenses
 
-### Update licenses
+Run `pnpm license:json` and `pnpm license:summary`. Disallowed licenses (GPL / LGPL / AGPL family) are blocked on PRs by [`dependency-review.yaml`](.github/workflows/dependency-review.yaml).
 
-```bash
-pnpm license:json
-pnpm license:summary
-```
-
-### Check for inappropriate licenses
-
-```bash
-bash checkLicense.sh
-```
+> [!NOTE]
+> Book, photo, and license data are also regenerated weekly by [`update-contents.yaml`](.github/workflows/update-contents.yaml), which opens a PR with the changes.
 
 ### Cloudflare deployment
 
@@ -149,31 +137,7 @@ Access [Cloudflare](https://dash.cloudflare.com/) to add DNS TXT record.
 
 ## 🧞 Commands
 
-All commands are run from the root of the project, from a terminal:
-
-| Command                 | Action                                         |
-| :---------------------- | :--------------------------------------------- |
-| `pnpm install`          | Installs dependencies                          |
-| `pnpm check`            | Check Astro types                              |
-| `pnpm dev`              | Starts local dev server at `localhost:4321`    |
-| `pnpm build`            | Build production site to `./dist`              |
-| `pnpm preview`          | Preview build locally                          |
-| `pnpm tsc`              | Check types with TypeScript                    |
-| `pnpm fmt`              | Check code format with Prettier                |
-| `pnpm fmt:fix`          | Format codes with Prettier                     |
-| `pnpm lint`             | Lint with ESLint                               |
-| `pnpm lint:fix`         | Fix lint with ESLint                           |
-| `pnpm lint:mark`        | Lint markdown files with markdownlint-cli2     |
-| `pnpm lint:mark:fix`    | Fix lint markdown files with markdownlint-cli2 |
-| `pnpm lint:css`         | Lint CSS files with Stylelint                  |
-| `pnpm lint:css:fix`     | Fix lint CSS files with Stylelint              |
-| `pnpm lint:secret`      | Lint secrets with secretlint                   |
-| `pnpm generate:book`    | Generate book data using Google Books API      |
-| `pnpm generate:photo`   | Generate photo paths                           |
-| `pnpm license:summary`  | Generate license summary                       |
-| `pnpm license:json`     | Generate license JSON                          |
-| `pnpm security`         | Security check with pnpm audit                 |
-| `pnpm snapshots:update` | Update visual regression snapshots             |
+All scripts are defined in [`package.json`](package.json) — run them with `pnpm <script>` from the project root.
 
 ## 🪝 Tags & Release
 

--- a/package.json
+++ b/package.json
@@ -38,12 +38,12 @@
       "pnpm lint:secret",
       "pnpm lint:css"
     ],
-    "src/**/*.{js, jsx, ts, tsx, astro}": [
+    "src/**/*.{js,jsx,ts,tsx,astro}": [
       "pnpm tsc",
       "pnpm lint"
     ],
-    "_markdown/**/*.md": "pnpm lint:mark",
-    "src/**/*.{css, astro}": "pnpm lint:css"
+    "**/*.md": "pnpm lint:mark",
+    "src/**/*.{css,astro}": "pnpm lint:css"
   },
   "dependencies": {
     "@astrojs/markdown-remark": "7.2.0",


### PR DESCRIPTION
## 概要

`workflow`（開発 / CI フロー）ドキュメントの不整合を解消し、保守性のため可能な限り **single source** 化しました。自明なもの（`package.json` の scripts 等）は記述から外し、CLAUDE.md は定義の再記述を避けて相対パス参照に寄せています。

## 不整合の修正

- **存在しない `checkLicense.sh` 参照を除去**（2 箇所）
  - README → 実態である `dependency-review.yaml` の `deny-licenses`（GPL/LGPL/AGPL 系をブロック）への参照に置換
  - CLAUDE.md「コミット前の確認」→ `package.json` の `lint-staged` 参照に置換
- **stale な `pnpm snapshots:update`**（該当 script なし）をコマンド表ごと削除で解消
- **Tech Stack の「Dependabot alert」**（リポジトリに dependabot 設定なし）→ 実態の OSV Scanner / Dependency Review に修正

## single source 化（重複削除）

- README「🧞 Commands」表（`package.json` scripts の丸写し・既にズレあり）→ `package.json` への 1 行ポインタに圧縮
- CLAUDE.md の `lint-staged` 再定義・リリース手順の重複を参照に置換
- CLAUDE.md「品質管理」を `.husky/` / `.github/workflows/` / `renovate.json5` への参照に

## 実態との整合（CI 自動化への参照を追加）

- 生成系（book / photo / license）が `update-contents.yaml` により**週次で自動実行され PR を作成**する旨を README / CLAUDE.md に追記

## 設定側の修正

- `package.json` の `lint-staged` グロブ修正
  - `_markdown/**/*.md`（存在しないディレクトリ）→ `**/*.md`
  - スペース入りで壊れていたグロブ 2 件を修正
- 上記で pre-commit の `lint:mark` が実働するようになったため、`.markdownlint-cli2.jsonc` に `gitignore: true` を追加し vendored（`.terraform` 等）を除外（ローカル lint を CI と一致させる）

## 検証

- `package.json` valid JSON
- `pnpm lint:mark` → 0 error（vendored 除外後）
- `pnpm fmt`（prettier）整形済み
- pre-commit フック全通過（check / lint:mark / fmt / lint:secret / lint:css）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * セキュリティチェック手順を明確化し、OSV Scanner の実行方法を追加
  * 開発ワークフローと品質管理プロセスの説明を更新

* **Chores**
  * リント設定を最適化
  * コマンドドキュメントを簡潔化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->