### PR TITLE
chore: enable stylelint on base.css and consolidate CSS lint

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -5,5 +5,3 @@ dist
 !*.css
 !*.astro
 LICENSE
-
-src/styles/base.css

--- a/.stylelintrc.mjs
+++ b/.stylelintrc.mjs
@@ -36,9 +36,22 @@ export default {
           "plugin",
           "source",
           "theme",
+          "custom-variant",
+          "utility",
+          "variant",
+          "reference",
         ],
       },
     ],
     "function-no-unknown": [true, { ignoreFunctions: ["theme", "screen"] }],
+    // Tailwind v4 の `@import "tailwindcss"` を許容（url 記法を強制しない）
+    "import-notation": "string",
+    // s-ui トークンの `rgb(var(--x) / 0.08)` 記法を尊重し number で統一
+    "alpha-value-notation": "number",
+    // `.text-gradient` の `-webkit-background-clip: text`（Safari 必須）を保護
+    "property-no-vendor-prefix": [
+      true,
+      { ignoreProperties: ["-webkit-background-clip"] },
+    ],
   },
 };

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,3 @@
-import eslintCss from "@eslint/css";
 import eslintJs from "@eslint/js";
 import eslintMarkdown from "@eslint/markdown";
 import tsParser from "@typescript-eslint/parser";
@@ -190,19 +189,6 @@ export default [
           ],
         },
       ],
-    },
-  },
-
-  // css (not in use)
-  {
-    files: ["**/*.css"],
-    ignores: ["**/base.css"], // Tailwind CSS 4の新しい構文のため除外
-    plugins: {
-      css: eslintCss,
-    },
-    language: "css/css",
-    rules: {
-      "css/use-baseline": ["error", { available: "widely" }],
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
   },
   "devDependencies": {
     "@astrojs/check": "0.9.9",
-    "@eslint/css": "1.3.0",
     "@eslint/js": "10.0.1",
     "@eslint/markdown": "8.0.2",
     "@secretlint/secretlint-rule-preset-recommend": "13.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,9 +69,6 @@ importers:
       '@astrojs/check':
         specifier: 0.9.9
         version: 0.9.9(prettier-plugin-astro@0.14.1)(prettier@3.8.3)(typescript@6.0.3)
-      '@eslint/css':
-        specifier: 1.3.0
-        version: 1.3.0
       '@eslint/js':
         specifier: 10.0.1
         version: 10.0.1(eslint@10.4.0(jiti@2.7.0))
@@ -798,14 +795,6 @@ packages:
 
   '@eslint/core@1.2.1':
     resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  '@eslint/css-tree@4.0.4':
-    resolution: {integrity: sha512-nxMparyhqVWQvadx9x8dIfubfIPOE+X2b2waua8fzdnM9vdp9rgVtwEZlG0TmCwEUz/d/f40fzvO/eqBwdxz0A==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  '@eslint/css@1.3.0':
-    resolution: {integrity: sha512-MwY657chvFQWtXmO86syZgD+JpWlzDq7VkKZyi65PwHDbhELQPMzPXh5s8rhrjptG6FCuls0puCmlXk66+14uA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@eslint/js@10.0.1':
@@ -4264,9 +4253,6 @@ packages:
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
-  mdn-data@2.28.1:
-    resolution: {integrity: sha512-U9w+PzSZ00Z5m9rZ5ARVFL5xOfuCHdKYi/1RRwDCJsboFgJDNT3zT6PIPD7mZQYaQLhsZM3GfDRgSMRHhSmVng==}
-
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
@@ -6610,17 +6596,6 @@ snapshots:
   '@eslint/core@1.2.1':
     dependencies:
       '@types/json-schema': 7.0.15
-
-  '@eslint/css-tree@4.0.4':
-    dependencies:
-      mdn-data: 2.28.1
-      source-map-js: 1.2.1
-
-  '@eslint/css@1.3.0':
-    dependencies:
-      '@eslint/core': 1.2.1
-      '@eslint/css-tree': 4.0.4
-      '@eslint/plugin-kit': 0.7.1
 
   '@eslint/js@10.0.1(eslint@10.4.0(jiti@2.7.0))':
     optionalDependencies:
@@ -10368,8 +10343,6 @@ snapshots:
   mdn-data@2.0.28: {}
 
   mdn-data@2.27.1: {}
-
-  mdn-data@2.28.1: {}
 
   mdurl@2.0.0: {}
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -47,6 +47,7 @@
 @layer base {
   body {
     @apply bg-background text-foreground;
+
     position: relative;
   }
 
@@ -132,6 +133,7 @@
     transform: translateY(16px) scale(0.98);
     filter: blur(4px);
   }
+
   to {
     opacity: 1;
     transform: translateY(0) scale(1);
@@ -146,27 +148,35 @@
 .bento-grid > :nth-child(1) {
   animation-delay: 0ms;
 }
+
 .bento-grid > :nth-child(2) {
   animation-delay: 60ms;
 }
+
 .bento-grid > :nth-child(3) {
   animation-delay: 120ms;
 }
+
 .bento-grid > :nth-child(4) {
   animation-delay: 180ms;
 }
+
 .bento-grid > :nth-child(5) {
   animation-delay: 240ms;
 }
+
 .bento-grid > :nth-child(6) {
   animation-delay: 300ms;
 }
+
 .bento-grid > :nth-child(7) {
   animation-delay: 360ms;
 }
+
 .bento-grid > :nth-child(8) {
   animation-delay: 420ms;
 }
+
 .bento-grid > :nth-child(9) {
   animation-delay: 480ms;
 }
@@ -191,6 +201,7 @@
   100% {
     background-position: 0% center;
   }
+
   50% {
     background-position: 100% center;
   }


### PR DESCRIPTION
## Why

stylelint は config・scripts・lint-staged・CI・pre-commit まで完全に統合されているのに、**実際のチェック対象がゼロ**で空回りしていた:

- 唯一の CSS ファイル `src/styles/base.css` が `.stylelintignore` で明示的に除外
- `.astro` ファイルに `<style>` ブロックは 1 つもない（スタイルは Tailwind クラス直書き）
- → `pnpm lint:css` は対象なしで黙って成功するだけ

さらに eslint 側の `@eslint/css`（`css/use-baseline`）も同じく base.css を除外し `// css (not in use)` 状態で、CSS lint が二重に死んでいた。

## What

base.css を実際のチェック対象に含め、Tailwind v4 構文に対応させて stylelint を機能させる。CSS lint は stylelint に一本化し、重複する `@eslint/css` を撤去:

- `.stylelintignore` から base.css を外す
- `.stylelintrc.mjs` に Tailwind v4 / 既存コード尊重のルールを追加
  - `at-rule-no-unknown` の `ignoreAtRules` に `custom-variant` / `utility` / `variant` / `reference`
  - `import-notation: "string"`（`@import "tailwindcss"` を許容）
  - `alpha-value-notation: "number"`（既存の `rgb(var(--x) / 0.08)` 記法を尊重、コード変更ゼロ）
  - `property-no-vendor-prefix` で `-webkit-background-clip`（Safari 必須）を保護
- `eslint.config.js` の未使用 `@eslint/css` ブロック + import を撤去し、devDependency も削除
- `src/styles/base.css` を `stylelint --fix` で整形（空行ルールのみ。意味変更なし）

## Verification

- `pnpm lint:css` → **0 errors**（base.css が対象に入った状態で）
- `pnpm fmt` → 無変更（prettier と競合なし）
- `pnpm lint`（eslint）→ パス（`@eslint/css` 撤去後も問題なし）
- `pnpm build` → success
- 動作確認: base.css に不正な `colr: red;` を一時投入 → `Unknown property "colr"` を検出することを確認（その後復元）

🤖 Generated with [Claude Code](https://claude.com/claude-code)