### PR TITLE
chore: harden stylelint config for Tailwind v4 directives/functions

### DIFF
--- a/.stylelintrc.mjs
+++ b/.stylelintrc.mjs
@@ -29,21 +29,34 @@ export default {
     "at-rule-no-unknown": [
       true,
       {
+        // Tailwind v4 公式ディレクティブを網羅して許容
+        // https://tailwindcss.com/docs/functions-and-directives
         ignoreAtRules: [
-          "tailwind",
+          "tailwind", // legacy 互換
           "layer",
           "apply",
-          "plugin",
+          "plugin", // legacy 互換（JS プラグイン読み込み、本プロジェクトで使用）
           "source",
           "theme",
           "custom-variant",
           "utility",
           "variant",
           "reference",
+          "config", // legacy 互換（JS 設定読み込み）— 網羅性のため
         ],
       },
     ],
-    "function-no-unknown": [true, { ignoreFunctions: ["theme", "screen"] }],
+    // Tailwind v4 の組み込み関数を許容（--alpha/--spacing は v4 新関数、theme/screen は legacy）
+    "function-no-unknown": [
+      true,
+      { ignoreFunctions: ["theme", "screen", "--alpha", "--spacing"] },
+    ],
+    // Tailwind v4 の build-time 関数（--spacing()/--alpha()）を値として使う宣言を許容
+    // （declaration-property-value-no-unknown は値の CSS 文法まで検証するため別途必要）
+    "declaration-property-value-no-unknown": [
+      true,
+      { ignoreProperties: { "/.+/": ["/^--(spacing|alpha)\\(/"] } },
+    ],
     // Tailwind v4 の `@import "tailwindcss"` を許容（url 記法を強制しない）
     "import-notation": "string",
     // s-ui トークンの `rgb(var(--x) / 0.08)` 記法を尊重し number で統一


### PR DESCRIPTION
## 概要

stylelint を Tailwind CSS v4 に正しく対応させる整備。専用パッケージは追加せず、超メジャーで活発メンテの公式 `stylelint-config-standard` をベースに、手動 allowlist を v4 公式準拠で網羅・堅牢化した。

### 背景

Tailwind v4 対応の専用 stylelint config を調査したが、いずれもマイナーだったため不採用とした:

| 候補 | star | v4対応 |
|---|---|---|
| `@dreamsicle.io/stylelint-config-tailwindcss` | 7 | ◎ 構文検証だが超マイナー・個人メンテ |
| `stylelint-config-tailwindcss` (zhilidali) | 19 | ✗ peer `tailwindcss>=2.2.16`、v3設計 |

メジャー性・メンテ性を満たす専用 config は存在しないため、公式ベース + 手動整備を選択。

## 変更内容 (`.stylelintrc.mjs` のみ)

- **`at-rule-no-unknown`**: レガシーディレクティブ `@config` を追加し、v4 公式ディレクティブを網羅。出典 URL と legacy 注記を明文化
- **`function-no-unknown`**: v4 新 build-time 関数 `--alpha` / `--spacing` を許容（`theme`/`screen` は legacy 維持）
- **`declaration-property-value-no-unknown`** (新規): `--spacing()` / `--alpha()` を**値として**使う宣言を許容。このルールは値の CSS 文法まで検証するため `function-no-unknown` だけでは不足だった。`ignoreProperties` で全プロパティ (`/.+/`) に対し Tailwind 関数値だけをピンポイント許容

現状 base.css はこれらの新構文を未使用のため、**予防的整備**（将来 v4 構文を増やしても lint が壊れない状態）であり既存の lint 結果は不変。

## 検証

- `pnpm lint:css`（全体）— エラーなしでパス
- 一時 CSS で `@config` / `margin: --spacing(4)` / `padding` / `gap` / `color: --alpha(...)` / `background-color` を実地確認 → すべて誤検知なし
- pre-commit (lint-staged) 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)